### PR TITLE
README: fix a Markdown syntax typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # node-mkfiletree
+
 Serialize an object to a file/directory tree. Available in npm as *mkfiletree*
 
 [![NPM](https://nodei.co/npm/mkfiletree.png?stars&downloads)](https://nodei.co/npm/mkfiletree/)
@@ -74,8 +75,7 @@ Clean up any temporary directories created with `makeTemp()` since the last `cle
 
 ### make(root, tree, callback)
 
-Same as `makeTemp() but you specify the exact root path *to be created* which will contain your directory tree. The callback also receives the `error` and `dir` arguments. Directories created with `make()` won't be removed with a `cleanUp()` call.
-
+Same as `makeTemp()` but you specify the exact root path *to be created* which will contain your directory tree. The callback also receives the `error` and `dir` arguments. Directories created with `make()` won't be removed with a `cleanUp()` call.
 
 ## Contributing
 


### PR DESCRIPTION
Nothing important. Good job on the library!
